### PR TITLE
Separated parser support block into snippet

### DIFF
--- a/_includes/doc/admin-guide/parser-support.md
+++ b/_includes/doc/admin-guide/parser-support.md
@@ -1,0 +1,2 @@
+If you find a message that the {{ page.parser }}-parser() cannot properly parse,
+contact Support, so we can improve the parser.

--- a/doc/_admin-guide/120_Parser/013_netskope_parser.md
+++ b/doc/_admin-guide/120_Parser/013_netskope_parser.md
@@ -16,9 +16,7 @@ For example:
 
 ><134>{"count": 1, "supporting_data": {"data_values": ["x.x.x.x", "user@domain.com"], "data_type": "user"}, "organization_unit": "domain/domain/Domain Users/Enterprise Users", "severity_level": 2, "category": null, "timestamp": 1547421943, "_insertion_epoch_timestamp": 1547421943, "ccl": "unknown", "user": "user@domain.com", "audit_log_event": "Login Successful", "ur_normalized": "user@domain.com", "_id": "936289", "type": "admin_audit_logs", "appcategory": null}
 
-If you find a message that the netskope-parser() cannot properly parse,
-contact Support, so we can improve
-the parser.
+{% include doc/admin-guide/parser-support.md %}
 
 The syslog-ng OSE application sets the ${PROGRAM} field to Netskope.
 

--- a/doc/_admin-guide/120_Parser/018_websense_parser.md
+++ b/doc/_admin-guide/120_Parser/018_websense_parser.md
@@ -17,9 +17,7 @@ For example:
 
 ><159>Dec 19 10:48:57 EST 192.168.1.1 vendor=Websense product=Security product_version=7.7.0 action=permitted severity=1 category=153 user=- src_host=192.168.2.1 src_port=62189 dst_host=example.com dst_ip=192.168.3.1 dst_port=443 bytes_out=197 bytes_in=76 http_response=200 http_method=CONNECT http_content_type=- http_user_agent=Mozilla/5.0_(Windows;_U;_Windows_NT_6.1;_enUS;_rv:1.9.2.23)_Gecko/20110920_Firefox/3.6.23 http_proxy_status_code=200 reason=- disposition=1034 policy=- role=8 duration=0 url=https://example.com
 
-If you find a message that the websense-parser() cannot properly parse,
-contact Support, so we can improve
-the parser.
+{% include doc/admin-guide/parser-support.md %}
 
 The syslog-ng OSE application sets the ${PROGRAM} field to Websense.
 

--- a/doc/_admin-guide/120_Parser/020_Fortigate_parser/README.md
+++ b/doc/_admin-guide/120_Parser/020_Fortigate_parser/README.md
@@ -1,6 +1,7 @@
 ---
 title: Fortigate parser
 id: adm-parser-fortigate
+parser: fortigate
 description: >-
     The Fortigate parser can parse the log messages of FortiGate/FortiOS
     (Fortigate Next-Generation Firewall (NGFW)).  
@@ -16,9 +17,7 @@ For example:
 
 ><189>date=2021-01-15 time=12:58:59 devname="FORTI_111" devid="FG100D3G12801312" logid="0001000014" type="traffic" subtype="local" level="notice" vd="root" eventtime=1610704739683510055 tz="+0300" srcip=91.234.154.139 srcname="91.234.154.139" srcport=45295 srcintf="wan1" srcintfrole="wan" dstip=213.59.243.9 dstname="213.59.243.9" dstport=46730 dstintf="unknown0" dstintfrole="undefined" sessionid=2364413215 proto=17 action="deny" policyid=0 policytype="local-in-policy" service="udp/46730" dstcountry="Russian Federation" srccountry="Russian Federation" trandisp="noop" app="udp/46730" duration=0 sentbyte=0 rcvdbyte=0 sentpkt=0 appcat="unscanned" crscore=5 craction=262144 crlevel="low"
 
-If you find a message that the fortigate-parser() cannot properly parse,
-contact Support, so we can improve
-the parser.
+{% include doc/admin-guide/parser-support.md %}
 
 By default, the Fortigate-specific fields are extracted into name-value
 pairs prefixed with .fortigate. For example, the devname in the previous

--- a/doc/_admin-guide/120_Parser/021_Checkpoint_parser.md
+++ b/doc/_admin-guide/120_Parser/021_Checkpoint_parser.md
@@ -20,9 +20,7 @@ Splunk format:
 
 >time=1557767758|hostname=r80test|product=Firewall|layer_name=Network|layer_uuid=c0264a80-1832-4fce-8a90-d0849dc4ba33|match_id=1|parent_rule=0|rule_action=Accept|rule_uid=4420bdc0-19f3-4a3e-8954-03b742cd3aee|action=Accept|ifdir=inbound|ifname=eth0|logid=0|loguid={0x5cd9a64e,0x0,0x5060a8c0,0xc0000001}|origin=192.168.96.80|originsicname=cn\=cp_mgmt,o\=r80test..ymydp2|sequencenum=1|time=1557767758|version=5|dst=192.168.96.80|inzone=Internal|outzone=Local|proto=6|s_port=63945|service=443|service_id=https|src=192.168.96.27|
 
-If you find a message that the checkpoint-parser() cannot properly
-parse, contact Support, so we can
-improve the parser.
+{% include doc/admin-guide/parser-support.md %}
 
 By default, the Check Point-specific fields are extracted into
 name-value pairs prefixed with **.checkpoint**. For example, the


### PR DESCRIPTION
Fixes: #56 

A sentence regarding contacting Support is separated into snippet for the sake of reusability.
Only existing instances are modified, might include to other parser pages as well.

'parser' property must be defined in page front matter for this to work properly, e.g.

\---
title: Fortigate parser
parser: fortigate
...
\---