### PR TITLE
External link and link alias modifications

### DIFF
--- a/_data/external_links.yml
+++ b/_data/external_links.yml
@@ -442,7 +442,7 @@ rfc-3162:
 
 rfc-3164:
   id: rfc-3164
-  url: https://www.ietf.org/rfc/rfc3164.txt
+  url: https://tools.ietf.org/html/rfc3164
   title: [ "RFC-3164" ]
 
 rfc-3339:
@@ -472,7 +472,7 @@ rfc-4627:
 
 rfc-5424:
   id: rfc-5424
-  url: https://tools.ietf.org/html/rfc5424#page-8
+  url: https://tools.ietf.org/html/rfc5424
   title: [ "RFC-5424" ]
 
 rfc-base64:
@@ -480,15 +480,15 @@ rfc-base64:
   url: https://tools.ietf.org/html/rfc4648
   title: [ "base64-encode" ]
 
-rfc-bsd-syslog-proto:
-  id: rfc-bsd-syslog-proto
-  url: https://www.ietf.org/rfc/rfc3164.txt
-  title: [ "legacy syslog (BSD-syslog) protocol" ]
+rfc-bsd-syslog-msg:
+  id: rfc-bsd-syslog-msg
+  url: https://tools.ietf.org/html/rfc3164#section-4.1
+  title: [ "legacy BSD-syslog message format" ]
 
-rfc-ietf-syslog-proto:
-  id: rfc-ietf-syslog-proto
-  url: https://tools.ietf.org/html/rfc5424
-  title: [ "IETF-syslog" ]
+rfc-ietf-syslog-msg:
+  id: rfc-ietf-syslog-msg
+  url: https://tools.ietf.org/html/rfc5424#page-8
+  title: [ "IETF-syslog message format" ]
 
 rfc-octet:
   id: rfc-octet

--- a/_data/external_links.yml
+++ b/_data/external_links.yml
@@ -432,12 +432,12 @@ welf:
 
 rfc-822:
   id: rfc-822
-  url: https://www.ietf.org/rfc/rfc822.txt
+  url: https://tools.ietf.org/html/rfc822
   title: [ "RFC-822" ]
 
 rfc-3162:
   id: rfc-3162
-  url: https://www.ietf.org/rfc/rfc3162.txt
+  url: https://tools.ietf.org/html/rfc3162
   title: [ "RFC-3162" ]
 
 rfc-3164:
@@ -447,17 +447,17 @@ rfc-3164:
 
 rfc-3339:
   id: rfc-3339
-  url: https://www.ietf.org/rfc/rfc3339.txt
+  url: https://tools.ietf.org/html/rfc3339
   title: [ "RFC-3339" ]
 
 rfc-3526:
   id: rfc-3526
-  url: https://www.ietf.org/rfc/rfc3526.txt
+  url: https://tools.ietf.org/html/rfc3526
   title: [ "RFC-3526" ]
 
 rfc-4122:
   id: rfc-4122
-  url: https://www.ietf.org/rfc/rfc4122.txt
+  url: https://tools.ietf.org/html/rfc4122
   title: [ "RFC-4122" ]
 
 rfc-4180:

--- a/_data/link_aliases.yml
+++ b/_data/link_aliases.yml
@@ -89,5 +89,14 @@ adm-temp-macro-ose#week_day_name-c_week_day_name-r_week_day_name-s_week_day_name
 adm-temp-macro-ose#year-c_year-r_year-s_year:
   aliases: [ "${YEAR}", "${C_YEAR}", "${R_YEAR}", "${S_YEAR}" ]
 
-adm-temp-macro-ose#year-c_year-r_year-s_year:
-  aliases: [ "[Ff]ully-qualified domain name", "FQDN" ]
+adm-about-glossary#fully-qualified-domain-name-fqdn:
+  aliases: [ "[Ff]ully [Qq]ualified [Dd]omain [Nn]ame", "FQDN" ]
+
+grpc-keep:
+  aliases: [ "gRPC keepalive pings", "gRPC keepalive ping", "gRPC ping" ]
+
+adm-about-glossary#bsd-syslog-protocol:
+  aliases: [ "BSD-syslog protocol", "legacy syslog (BSD-syslog) protocol" ]
+
+adm-about-glossary#ietf-syslog-protocol:
+  aliases: [ "IETF-syslog protocol", "IETF-syslog" ]

--- a/_includes/doc/admin-guide/options/log-msg-size.md
+++ b/_includes/doc/admin-guide/options/log-msg-size.md
@@ -7,8 +7,8 @@
 length includes the entire message (the data structure and individual
 fields). The maximal value that can be set is 268435456 bytes (256 MiB).
 
-For messages using the IETF-syslog message format (RFC-5424), the maximal
-size of the value of an SDATA field is 64 KiB.
+For messages using the IETF-syslog message format, the maximal
+size of the value of an `SDATA` field is 64 KiB.
 
 **NOTE:** In most cases, log-msg-size() does not need to be set higher than
 10 MiB.

--- a/doc/_admin-guide/190_The_syslog-ng_manual_pages/001_loggen.md
+++ b/doc/_admin-guide/190_The_syslog-ng_manual_pages/001_loggen.md
@@ -175,9 +175,9 @@ statistics:
 
 - \--syslog-proto or -P
 
-    Use the new IETF-syslog message format as specified in RFC-5424. By
-    default, loggen uses the legacy BSD-syslog message format (as
-    described in RFC-3164). See also the \--no-framing option.
+    Use the new IETF-syslog message format. By
+    default, loggen uses the legacy BSD-syslog message format.
+	See also the \--no-framing option.
 
 - \--unix \</path/to/socket\> or -x \</path/to/socket\>
 


### PR DESCRIPTION
Fixes: #55 

- Replaced plaintext RFC links to html in external_links
- Created aliases for gRPC keepalive ping(s)
- Fixed FQDN alias duplicate ID
- Made FQDN alias case insensitive
- Created external link for IETF-syslog message format
- Eliminated some external link redundancies around IETF-syslog and BSD-syslog
- Adjusted markdown to avoid redundant texts.