### PR TITLE
Autolink tooltip does not work directly for titles with liquid markdown expressions 61

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -56,7 +56,7 @@ include:
   - assets/js/main.min.js
   # Only lunr is not included now to main.min.js
   - assets/js/lunr
-  # site.data.links input
+  # Input of site.data.links
   - _data/links/
 exclude:
   - .reftime
@@ -178,9 +178,11 @@ search_from_masthead: true
 
 search_provider: lunr
 lunr:
-  # No we have all the valuable content in collections
+  # No we have all the valuable content in collections (collection.docs) 
+  # that lunr indexes by default if search: true
   # Standalone pages like, sitemap.xml, 404, etc. should not be searched
   search_within_pages: false
+  test_text_1: "abrakadabra"
 
 # search_provider: algolia
 # algolia:

--- a/_js/lunr/lunr-en.js
+++ b/_js/lunr/lunr-en.js
@@ -81,7 +81,7 @@ $(document).ready(function() {
           '<div class="list__item">' +
           '<article class="archive__item" itemscope itemtype="https://schema.org/CreativeWork">' +
           '<h2 class="archive__item-title" itemprop="headline">' +
-          '<a href="' + removeExtension(tore[ref].url) + '" onclick="searchResultLinkClickHandler(event)" rel="permalink">' + store[ref].title + '</a>' +
+          '<a href="' + removeExtension(store[ref].url) + '" onclick="searchResultLinkClickHandler(event)" rel="permalink">' + store[ref].title + '</a>' +
           '</h2>' +
           '<div class="archive__item-teaser">' +
           '<img src="' + store[ref].teaser + '" alt="">' +

--- a/_plugins/generate_links.rb
+++ b/_plugins/generate_links.rb
@@ -44,8 +44,14 @@ module Jekyll
         end
       end
 
+      def render_title(page, title)
+        context = page.site.site_payload['site']
+        template = Liquid::Template.parse(title)
+        return template.render('site' => context)
+      end
+    
     public
-      
+
       def generate_links(page, ids, titles)
         #puts page.relative_path
         # Must have to get it parsed by jekyll, these links will be part of the site.data.links array as well, do not touch them
@@ -81,7 +87,7 @@ module Jekyll
               link_data = {
                 "id" => page_id + "##{heading_id}",
                 "url" => page_url + "##{heading_id}",
-                "title" => '"' + heading.text + '"',
+                "title" => '"' + render_title(page, heading.text) + '"',
               }
               #register_id(page, link_data["id"], link_data["title"], ids, titles)
 
@@ -104,7 +110,7 @@ module Jekyll
             link_data = {
               "id" => anchor_id,
               "url" => page_url + "##{anchor_name}",
-              "title" => '"' + (anchor_text.empty? ? anchor_id : anchor_text) + '"',
+              "title" => '"' + (anchor_text.empty? ? anchor_id : render_title(page, anchor_text)) + '"',
             }
             #register_id(page, link_data["id"], link_data["title"], ids, titles)
 
@@ -114,7 +120,7 @@ module Jekyll
           end
 
           # Create links data for the page itself too
-          page_title = page.data["title"]
+          page_title = render_title(page, page.data["title"])
           page_link_data = {
             "id" => page_id,
             "url" => page_url,

--- a/doc/_doc-guide/02_Tools/01_Self_made_tools/01_Tests/README.md
+++ b/doc/_doc-guide/02_Tools/01_Self_made_tools/01_Tests/README.md
@@ -61,6 +61,10 @@ options {
 };
 ```
 
+## Tests of custom markdown in header [[source]] and [[with turumturum id|doc-jekyll-extensions#titleid-markdown-extension]]
+
+## Tests of liquid expression {{ site.lunr.test_text_1 }} in header of {{ site.title }}
+
 ---------------------
 
 Introduction to {{ site.product.short_name }} is a test for pages without description/subtitle, but text part between the title and the first heading which can have tooltips too this way.


### PR DESCRIPTION
Added title liquid pre-rendering to the link generation phase

- autolink/tooltip generation now can handle liquid variables in titles
Signed-off-by: Hofi <hofione@gmail.com>