### PR TITLE
Random doc fixes

### DIFF
--- a/doc/_admin-guide/020_The_concepts_of_syslog-ng/007_The_structure_of_a_log_message/001_IETF_syslog_messages.md
+++ b/doc/_admin-guide/020_The_concepts_of_syslog-ng/007_The_structure_of_a_log_message/001_IETF_syslog_messages.md
@@ -12,7 +12,7 @@ A syslog message consists of the following parts:
 - [[STRUCTURED-DATA|adm-struct-ietf#the-structured-data-message-part]]
 - [[MSG|adm-struct-ietf#the-msg-message-part]]
 
-The following is a sample syslog message [(source)|rfc-5424]:
+The following is a sample syslog message [[(source)|rfc-5424]]:
 
 ><34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47 - BOM'su root' failed for lonvick on /dev/pts/8
 

--- a/doc/_admin-guide/070_Destinations/270_sql/000_Using_sql_driver_with_Oracle.md
+++ b/doc/_admin-guide/070_Destinations/270_sql/000_Using_sql_driver_with_Oracle.md
@@ -25,6 +25,14 @@ to note.
 - As certain database versions limit the maximum length of table
     names, macros in the table names should be used with care.
 
+- The Oracle Instant Client used by {{ site.product.short_name }} supports only the
+    following character sets:
+
+  - Single-byte character sets: US7ASCII, WE8DEC, WE8MSWIN1252, and
+        WE8ISO8859P1
+
+  - Unicode character sets: UTF8, AL16UTF16, and AL32UTF8
+
 - In the current version of {{ site.product.short_name }}, the types of database
     columns must be explicitly set for the Oracle destination. The
     column used to store the text part of the syslog messages should be
@@ -33,14 +41,6 @@ to note.
     **varchar2** or **clob** column type. (The maximum length of the
     messages can be set using the log-msg-size() option.) For details,
     see the following example.
-
-- The Oracle Instant Client used by {{ site.product.short_name }} supports only the
-    following character sets:
-
-  - Single-byte character sets: US7ASCII, WE8DEC, WE8MSWIN1252, and
-        WE8ISO8859P1
-
-  - Unicode character sets: UTF8, AL16UTF16, and AL32UTF8
 
 ### Example: Using the sql() driver with an Oracle database
 


### PR DESCRIPTION
Fixed a missing [] from our custom markdown notation usage and reordered an oracle doc part that refers to an example to get it closer to the referred example

Signed-off-by: Hofi <hofione@gmail.com>