### PR TITLE
Unified multi-line term usage

### DIFF
--- a/doc/_admin-guide/060_Sources/090_mbox/README.md
+++ b/doc/_admin-guide/060_Sources/090_mbox/README.md
@@ -4,7 +4,7 @@ short_title: mbox
 id: adm-src-mbox
 description: >-
     Using the mbox() driver, {{ site.product.short_name }} can read email messages from
-    local mbox files, and convert them to multiline log messages.
+    local mbox files, and convert them to multi-line log messages.
 ---
 
 This driver has only one required option, the filename of the mbox file.

--- a/doc/_admin-guide/060_Sources/README.md
+++ b/doc/_admin-guide/060_Sources/README.md
@@ -114,7 +114,7 @@ The following table lists the source drivers available in syslog-ng.
 |internal()|Messages generated internally in syslog-ng.|
 |network()|Receives messages from remote hosts using the BSD-syslog protocol over IPv4 and IPv6. Supports the TCP, UDP, and TLS network protocols.|
 |nodejs()|Receives JSON messages from nodejs applications.|
-|mbox()|Read email messages from local mbox files, and convert them to multiline log messages.|
+|mbox()|Read email messages from local mbox files, and convert them to multi-line log messages.|
 |osquery()|Run osquery queries, and convert their results into log messages.|
 |pacct()|Reads messages from the process accounting logs on Linux.|
 |pipe()|Opens the specified named pipe and reads messages.|

--- a/doc/_admin-guide/120_Parser/004_XML_parser/README.md
+++ b/doc/_admin-guide/120_Parser/004_XML_parser/README.md
@@ -123,7 +123,7 @@ any of the following options:
 
 - Ensure that the XML is a single-line message.
 
-- In the case of multiline XML documents:
+- In the case of multi-line XML documents:
 
   - If the opening and closing tags are fixed and known, you can use
         **multi-line-mode(prefix-suffix)**. Using regular expressions,

--- a/doc/_admin-guide/190_The_syslog-ng_manual_pages/010_syslog-ng_conf.md
+++ b/doc/_admin-guide/190_The_syslog-ng_manual_pages/010_syslog-ng_conf.md
@@ -227,7 +227,7 @@ listed below.
 |internal()                    |Messages generated internally in {{ site.product.short_name }}.
 |network()                     |Receives messages from remote hosts using the BSD-syslog protocol over IPv4 and IPv6. Supports the TCP, UDP, and TLS network protocols.
 |nodejs()                      |Receives JSON messages from nodejs applications.
-|mbox()                        |Read e-mail messages from local mbox files, and convert them to multiline log messages.
+|mbox()                        |Read e-mail messages from local mbox files, and convert them to multi-line log messages.
 |osquery()                     |Run osquery queries, and convert their results into log messages.
 |pacct()                       |Reads messages from the process accounting logs on Linux.
 |pipe()                        |Opens the specified named pipe and reads messages.


### PR DESCRIPTION
In some documents the term "multiline" was used, without a dash. But in the grammar and all other places in the documents it is used in "multi-line" form. Now it's "multi-line" everywhere.