### PR TITLE
multi-line-timeout() option added to documentation

### DIFF
--- a/_data/external_links.yml
+++ b/_data/external_links.yml
@@ -92,6 +92,11 @@ sn-docker-log:
   url: https://www.syslog-ng.com/whitepaper/logging-in-docker-using-syslogng8132325/
   title: [ "Logging in Docker using syslog-ng" ]
 
+sn-ml-timeout:
+  id: sn-ml-timeout
+  url: https://www.syslog-ng.com/community/b/blog/posts/multi-line-timeout-making-sure-your-last-multi-line-message-is-not-lost
+  title: [ "Multi-line-timeout: making sure your last multi-line message is not lost"]
+
 sn-ose:
   id: sn-ose
   url: https://syslog-ng.com/

--- a/_includes/doc/admin-guide/options/multi-line-timeout.md
+++ b/_includes/doc/admin-guide/options/multi-line-timeout.md
@@ -1,0 +1,28 @@
+## multi-line-timeout()
+
+|  Type:|      time in seconds|
+|Default:| N/A|
+
+*Description:*  Specifies the time {{ site.product.short_name }} waits without reading new data from the source, before
+the last (potentially partial) message is flushed and sent through the pipeline as a LogMessage.
+
+Since the multi-line source detects the end of a message after finding the beginning of the subsequent message
+(indented or no-garbage/suffix mode), this option can be used to flush the last multi-line message
+in the file after a multi-line-timeout()-second timeout.
+
+There is no default value, so it must be explicitly configured. It should be a higher value than follow-freq(), so we recommend to set it to a multiple value of follow-freq().
+
+### Example: multi-line-timeout()
+
+```config
+source s_multi {
+ file("/some/folder/events"
+  multi-line-mode("prefix-garbage")
+  multi-line-prefix('^EVENT: ')
+  multi-line-timeout(10)
+  flags("no-parse")
+ );
+}
+```
+
+For more details see the blogpost Multi-line-timeout: making sure your last multi-line message is not lost.

--- a/_includes/doc/admin-guide/options/multi-line-timeout.md
+++ b/_includes/doc/admin-guide/options/multi-line-timeout.md
@@ -1,16 +1,13 @@
 ## multi-line-timeout()
 
-|  Type:|      time in seconds|
+|  Type:| number|
 |Default:| N/A|
 
-*Description:*  Specifies the time {{ site.product.short_name }} waits without reading new data from the source, before
-the last (potentially partial) message is flushed and sent through the pipeline as a LogMessage.
+*Description:*  Specifies the time (in seconds) {{ site.product.short_name }} waits without reading new data from the source, before the last (potentially partial) message is flushed and sent through the pipeline as a LogMessage.
 
-Since the multi-line source detects the end of a message after finding the beginning of the subsequent message
-(indented or no-garbage/suffix mode), this option can be used to flush the last multi-line message
-in the file after a multi-line-timeout()-second timeout.
+Since the multi-line source detects the end of a message via finding the beginning of the subsequent message (indented or no-garbage/suffix mode), this option can be used to flush the last multi-line message in the file after a given time.
 
-There is no default value, so it must be explicitly configured. It should be a higher value than follow-freq(), so we recommend to set it to a multiple value of follow-freq().
+There is no default value, so it must be explicitly configured with a value higher than follow-freq(). We recommend it to be set to a multiple of follow-freq().
 
 ### Example: multi-line-timeout()
 
@@ -25,4 +22,4 @@ source s_multi {
 }
 ```
 
-For more details see the blogpost Multi-line-timeout: making sure your last multi-line message is not lost.
+For more details see the blog post Multi-line-timeout: making sure your last multi-line message is not lost.

--- a/doc/_admin-guide/060_Sources/020_File/001_File_source_options.md
+++ b/doc/_admin-guide/060_Sources/020_File/001_File_source_options.md
@@ -35,6 +35,8 @@ The file() driver has the following options:
 
 {% include doc/admin-guide/options/multi-line-suffix.md %}
 
+{% include doc/admin-guide/options/multi-line-timeout.md %}
+
 {% include doc/admin-guide/options/pad-size.md %}
 
 {% include doc/admin-guide/options/program-override.md %}

--- a/doc/_admin-guide/060_Sources/030_Wildcard-file/000_Wildcard-file_options.md
+++ b/doc/_admin-guide/060_Sources/030_Wildcard-file/000_Wildcard-file_options.md
@@ -124,6 +124,8 @@ available, set this option to **poll**.
 
 {% include doc/admin-guide/options/multi-line-suffix.md %}
 
+{% include doc/admin-guide/options/multi-line-timeout.md %}
+
 {% include doc/admin-guide/options/pad-size.md %}
 
 {% include doc/admin-guide/options/program-override.md %}

--- a/doc/_admin-guide/060_Sources/110_Pipe/000_Pipe_source_options.md
+++ b/doc/_admin-guide/060_Sources/110_Pipe/000_Pipe_source_options.md
@@ -31,6 +31,8 @@ The pipe driver has the following options:
 
 {% include doc/admin-guide/options/multi-line-suffix.md %}
 
+{% include doc/admin-guide/options/multi-line-timeout.md %}
+
 {% include doc/admin-guide/options/optional.md %}
 
 {% include doc/admin-guide/options/pad-size.md %}

--- a/doc/_admin-guide/060_Sources/230_stdin/000_stdin_options.md
+++ b/doc/_admin-guide/060_Sources/230_stdin/000_stdin_options.md
@@ -36,6 +36,8 @@ The stdin() driver has the following options:
 
 {% include doc/admin-guide/options/multi-line-suffix.md %}
 
+{% include doc/admin-guide/options/multi-line-timeout.md %}
+
 {% include doc/admin-guide/options/pad-size.md %}
 
 {% include doc/admin-guide/options/program-override.md %}


### PR DESCRIPTION
The multi-line-timeout() option was totally missing from documentation of multi-line capable sources.
Added a snippet to fix this.