### PR TITLE
Documented threaded flag() issue workaround

### DIFF
--- a/_includes/doc/admin-guide/options/source-flags.md
+++ b/_includes/doc/admin-guide/options/source-flags.md
@@ -117,6 +117,17 @@
     destination. For details on multithreading, see
     Multithreading and scaling in {{ site.product.short_name }}.
 
+    If a parsing or syntax error occurs, use `"threaded"` nested in quotation marks.
+
+    ```config
+    flags(
+        validate-utf8
+        "threaded"
+        store-raw-message
+    )
+    ```
+  
+
     **NOTE:** The file destination uses multiple threads only if the
     destination filename contains macros.
     {: .notice--info}


### PR DESCRIPTION
Included quotation mark workaround for the threaded option within flags().

Signed-off-by: Zsolt Gyulai (zgyulai) <zsolt.gyulai@quest.com>