### PR TITLE
Deprecated pass-unix-credentials() and added so-passcreds()

### DIFF
--- a/doc/_admin-guide/090_Global_options/000_Global_options.md
+++ b/doc/_admin-guide/090_Global_options/000_Global_options.md
@@ -305,18 +305,9 @@ Starting with version 3.16, the default value of this option is -1, so
 {{ site.product.short_name }} does not change the ownership, unless explicitly
 configured to do so.
 
-## pass-unix-credentials()
+## pass-unix-credentials() (DEPRECATED)
 
-|  Accepted values:|   yes \| no|
-|Default:|           yes|
-
-*Description:* Enable {{ site.product.short_name }} to collect UNIX credential
-information (that is, the `PID`, user ID, and group of the sender process)
-for messages received using UNIX domain sockets. Available only in
-{{ site.product.name }} 3.7 and later. Note that collecting UNIX
-credential information from sockets in high-traffic environments can be
-resource intensive, therefore pass-unix-credentials() can be disabled
-globally, or separately for each source.
+The `pass-unix-credentials()` option has been deprecated in {{ site.product.short_name }} 3.35 and later versions. Use the `so-passcred()` option.
 
 {% include doc/admin-guide/options/perm.md %}
 
@@ -423,6 +414,15 @@ The following sub-options are available within the stats() option:
     To disable dynamic counters completely, set the value of this option to 0. This is the recommended value if  statistics are not used, or if dynamic counters are irrelevant (for example, the number of logs arriving from programs).
 
 **NOTE:** If a lower value is set to stats-max-dynamics() (or, any limiting value, if this option has not been configured before) and {{ site.product.short_name }} is restarted, the changes are only applied after stats-freq() time has passed. That is, the previously allocated dynamic clusters are only removed after this time.
+
+## so-passcred()
+
+|Accepted values:|   `yes`, `no`|
+|Default:        |         `yes`|
+
+*Description:* Enable {{ site.product.short_name }} to collect credential
+information (that is, the `PID`, user ID, and group of the sender process)
+for messages received using UNIX domain sockets.
 
 ## syslog-stats()
 


### PR DESCRIPTION
Deprecated pass-unix-credentials() and added so-passcreds()

Signed-off-by: Zsolt Gyulai (zgyulai) <zsolt.gyulai@quest.com>
