### PR TITLE
hypr backtick fixes

### DIFF
--- a/doc/_admin-guide/060_Sources/031_Hypr/000_Hypr_options.md
+++ b/doc/_admin-guide/060_Sources/031_Hypr/000_Hypr_options.md
@@ -1,9 +1,9 @@
 ---
-title: `hypr-audit-trail()` and `hypr-app-audit-trail()` source options
+title: hypr-audit-trail() and hypr-app-audit-trail() source options
 id: adm-src-hypr-opt
 ---
 
-The `hypr-audit-trail()` and `hypr-app-audit-trail() sources have the following options:
+The `hypr-audit-trail()` and `hypr-app-audit-trail()` sources have the following options:
 
 ## url()
 


### PR DESCRIPTION
Backtick usage in title caused some errors in jekyll.
Also, one backtick was not closed.