### PR TITLE
pipe source: create-dir() workaround

### DIFF
--- a/_includes/doc/admin-guide/options/create-dirs.md
+++ b/_includes/doc/admin-guide/options/create-dirs.md
@@ -5,3 +5,6 @@
 
 *Description:* Enable creating non-existing directories when creating
 files or socket files.
+
+**NOTE:** If syslog-ng cannot create the pipe, it aborts and produces an error. This could be caused by the lack of a write permission, or missing directory. The latter of the two can be fixed by using the `create-dirs(yes)` option.
+{: .notice--info}

--- a/doc/_admin-guide/060_Sources/110_Pipe/README.md
+++ b/doc/_admin-guide/060_Sources/110_Pipe/README.md
@@ -12,6 +12,9 @@ The pipe driver has a single required parameter, specifying the filename
 of the pipe to open. For the list of available optional parameters, see
 pipe() source options.
 
+**NOTE:** If syslog-ng cannot create the pipe, it aborts and produces an error. This could be caused by the lack of a write permission, or missing directory. The latter of the two can be fixed by using the `create-dirs(yes)` option.
+{: .notice--info}
+
 **Declaration**
 
 ```config


### PR DESCRIPTION
Added note about possible failure and workaround for pipe sources.