### PR TITLE
unix-dgram reliability

### DIFF
--- a/doc/_admin-guide/060_Sources/220_unix-stream_unix-dgram/README.md
+++ b/doc/_admin-guide/060_Sources/220_unix-stream_unix-dgram/README.md
@@ -4,10 +4,8 @@ short_title: unix-stream, unix-dgram
 id: adm-src-unix
 description: >-
     The unix-stream() and unix-dgram() drivers open an AF_UNIX socket and
-    start listening on it for messages. The unix-stream() driver is
-    primarily used on Linux and uses SOCK_STREAM semantics (connection
-    oriented, no messages are lost), while unix-dgram() is used on BSDs and
-    uses SOCK_DGRAM semantics: this may result in lost local messages if
+    start listening on it for messages. On Linux both the unix-stream() and unix-dgram() drivers are used and are always reliable,
+    while unix-dgram() is used on BSDs and uses SOCK_DGRAM semantics: this may result in lost local messages if
     the system is overloaded.
 ---
 

--- a/doc/_admin-guide/060_Sources/220_unix-stream_unix-dgram/README.md
+++ b/doc/_admin-guide/060_Sources/220_unix-stream_unix-dgram/README.md
@@ -4,7 +4,8 @@ short_title: unix-stream, unix-dgram
 id: adm-src-unix
 description: >-
     The unix-stream() and unix-dgram() drivers open an AF_UNIX socket and
-    start listening on it for messages. On Linux both the unix-stream() and unix-dgram() drivers are used and are always reliable,
+    start listening on it for messages. On Linux both the unix-stream() and unix-dgram() drivers are used and are always reliable. The unix-stream() driver uses SOCK_STREAM semantics (connection
+    oriented, no messages are lost),
     while unix-dgram() is used on BSDs and uses SOCK_DGRAM semantics: this may result in lost local messages if
     the system is overloaded.
 ---


### PR DESCRIPTION
Adjusted description to state that unix domain sockets are reliable.

PR belongs to the following issue:
https://github.com/syslog-ng/syslog-ng.github.io/issues/130