### PR TITLE
gRPC headers

### DIFF
--- a/_includes/doc/admin-guide/options/headers-gRPC.md
+++ b/_includes/doc/admin-guide/options/headers-gRPC.md
@@ -1,0 +1,17 @@
+## headers()
+
+|  Type: |      arrow list|
+|Default:|           empty|
+
+Available in syslog-ng OSE 4.8 and later versions.
+
+*Description:* Adds custom gRPC headers to each RPC call. Currently only static header names and values are supported.
+
+```config
+headers(
+    "organization" => "org-name"
+    "stream-name" => "org-stream"
+  )
+```
+
+> *Copyright © 2024 Axoflow*

--- a/doc/_admin-guide/070_Destinations/045_Google_bigQuery/000_bigquery_dest_options.md
+++ b/doc/_admin-guide/070_Destinations/045_Google_bigQuery/000_bigquery_dest_options.md
@@ -44,6 +44,8 @@ Available in {{ site.product.short_name }} 4.5 and later versions.
 
 {% include doc/admin-guide/options/frac-digits.md %}
 
+{% include doc/admin-guide/options/headers-gRPC.md %}
+
 {% include doc/admin-guide/options/hook.md %}
 
 {% include doc/admin-guide/options/keep-alive.md %}

--- a/doc/_admin-guide/070_Destinations/125_Loki/001_Loki_options.md
+++ b/doc/_admin-guide/070_Destinations/125_Loki/001_Loki_options.md
@@ -68,6 +68,8 @@ destination {
 
 {% include doc/admin-guide/options/channel-args.md %}
 
+{% include doc/admin-guide/options/headers-gRPC.md %}
+
 {% include doc/admin-guide/options/gRPC-keep-alive.md %}
 
 ## labels()

--- a/doc/_admin-guide/070_Destinations/157_OpenTelemetry/000_opentelemetry-destination-options.md
+++ b/doc/_admin-guide/070_Destinations/157_OpenTelemetry/000_opentelemetry-destination-options.md
@@ -75,4 +75,6 @@ Available in syslog-ng OSE 4.5 and later versions.
 
 *Description:* This option enables compression in gRPC requests. Currently, only the deflate compression method is supported.
 
+{% include doc/admin-guide/options/headers-gRPC.md %}
+
 {% include doc/admin-guide/options/workers.md %}


### PR DESCRIPTION
Included gRPC headers option for loki, bigquery and opentelemetry destinations.

Signed-off-by: Zsolt Gyulai (zgyulai) <zsolt.gyulai@quest.com>
