### PR TITLE
Removed explicit ID from title

### DIFF
--- a/doc/_admin-guide/110_Template_and_rewrite/001_Modifying_messages/002_Setting_severity.md
+++ b/doc/_admin-guide/110_Template_and_rewrite/001_Modifying_messages/002_Setting_severity.md
@@ -1,5 +1,5 @@
 ---
-title: Setting severity with the [[set-severity()|adm-temp-severity]] rewrite function
+title: Setting severity with the set-severity() rewrite function
 short_title: Setting severity
 id: adm-temp-severity
 description: >-
@@ -62,4 +62,5 @@ rewrite {
     set-severity("${.json.severity}");
 };
 ```
+
 {% include doc/admin-guide/warnings/dotdot-stringonly.md %}


### PR DESCRIPTION
Removed explicit ID from title, because it is redundant and not rendering properly. Plus, it borked up linking from another page.