### PR TITLE
kv-parser small fix

### DIFF
--- a/_includes/doc/admin-guide/default-prefix.md
+++ b/_includes/doc/admin-guide/default-prefix.md
@@ -1,8 +1,8 @@
-By default, {{ page.parser }}-parser() uses the .{{ page.prefix | default: page.parser }}. prefix. To modify it, use
+By default, {{ page.parser }}() uses the .{{ page.prefix | default: page.parser }}. prefix. To modify it, use
 the following format:
 
 ```config
 parser {
-    {{page.parser}}-parser(prefix("myprefix."));
+    {{page.parser}}(prefix("myprefix."));
 };
 ```

--- a/_includes/doc/admin-guide/default-prefix.md
+++ b/_includes/doc/admin-guide/default-prefix.md
@@ -1,8 +1,8 @@
-By default, {{ page.parser }}() uses the .{{ page.prefix | default: page.parser }}. prefix. To modify it, use
+By default, {{ page.parser }}-parser() uses the .{{ page.prefix | default: page.parser }}. prefix. To modify it, use
 the following format:
 
 ```config
 parser {
-    {{page.parser}}(prefix("myprefix."));
+    {{page.parser}}-parser(prefix("myprefix."));
 };
 ```

--- a/doc/_admin-guide/120_Parser/002_Parsing_key-value_pairs/000_kv_parser_options.md
+++ b/doc/_admin-guide/120_Parser/002_Parsing_key-value_pairs/000_kv_parser_options.md
@@ -1,6 +1,6 @@
 ---
 title: Options of key=value parsers
-parser: kv-parser
+parser: kv
 prefix: kv
 id: adm-parser-kv-opt
 description: >-


### PR DESCRIPTION
Fixed small error of the phrase "parser" being duplicated in text and in a codeblock.