### PR TITLE
file() to wildcard-file()

### DIFF
--- a/doc/_admin-guide/060_Sources/020_File/README.md
+++ b/doc/_admin-guide/060_Sources/020_File/README.md
@@ -1,9 +1,9 @@
 ---
-title: 'file: Collecting messages from text files'
-short_title: file
+title: 'file: Collecting messages from text files (DEPRECATED)'
+short_title: file (DEPRECATED)
 id: adm-src-file
 description: >-
-    Collects log messages from plain-text files, for example, from the logfiles of
+    The file() source has been deprecated. For a more stable performance, use the [[wildcard-file() source|adm-src-wild]] instead. Collects log messages from plain-text files, for example, from the logfiles of
     an Apache webserver. If you want to use wildcards in the filename, use the [[wildcard-file() source|adm-src-wild]].
 ---
 

--- a/doc/_dev-guide/chapter_4/section_2/macos-testing-status/affile/file-source-driver.md
+++ b/doc/_dev-guide/chapter_4/section_2/macos-testing-status/affile/file-source-driver.md
@@ -1,7 +1,7 @@
 ---
-title: file() Source Driver
+title: file() Source Driver (DEPRECATED)
 description: >-
-  The file() source driver is used to collect log messages from plain-text
+  The file() source has been deprecated. For a more stable performance, use the [[wildcard-file() source|adm-src-wild]] instead. The file() source driver is used to collect log messages from plain-text
   files, for example, from the logfiles of an Apache webserver.
 id: dev-macos-mod-sup-file-source
 ---


### PR DESCRIPTION
Marked file() as deprecated and advised the users to use wildcard.