### PR TITLE
Remove unparsed HTML entities [opensearch]

### DIFF
--- a/doc/_admin-guide/070_Destinations/155_opensearch/README.md
+++ b/doc/_admin-guide/070_Destinations/155_opensearch/README.md
@@ -17,7 +17,7 @@ description: >-
 ```config
 d_opensearch {
     opensearch(
-        index("&lt;opensearch-index-to-store-messages&gt;")
+        index("opensearch-index-to-store-messages")
         url("https://your-opensearch-endpoint:9200/_bulk")
     );
 };
@@ -30,7 +30,7 @@ The following example defines an opensearch() destination, using only the requir
 ```config
 destination opensearch {
     opensearch(
-        index("&lt;name-of-the-index&gt;")
+        index("name-of-the-index")
         url("http://my-elastic-server:9200/_bulk")
     );
 };


### PR DESCRIPTION
These are not parsed and are passed as literals. Removed `<` and `>` completely.