### PR TITLE
fix: Typo

### DIFF
--- a/doc/_admin-guide/070_Destinations/100_Kafka-c/000_Before_you_begin.md
+++ b/doc/_admin-guide/070_Destinations/100_Kafka-c/000_Before_you_begin.md
@@ -47,7 +47,7 @@ implementation, using only the required parameters.
 @include "scl.conf"
 
 destination d_kafka {
-    kafka(
+    kafka-c(
     bootstrap-servers("1.2.3.4:9092,192.168.0.2:9092")
     topic("{MYTOPIC}")
     );


### PR DESCRIPTION
if it is 
```
destination d_kafka {
    kafka(
    bootstrap-servers("1.2.3.4:9092,192.168.0.2:9092")
    topic("{MYTOPIC}")
    );
```
the docker syslog-ng wont work

and i found this  https://www.syslog-ng.com/community/b/blog/posts/kafka-destination-improved-with-template-support-in-syslog-ng

it may should be 
```
destination d_kafka {
  kafka-c(config(metadata.broker.list("localhost:9092")
                   queue.buffering.max.ms("1000"))
        topic("mytest")
        message("$(format-json --scope rfc5424 --scope nv-pairs)"));
};
```

and i change it from `kafka` to `kafka-c`, it works really well

the docker image i use is ` balabit/syslog-ng:latest`
