### PR TITLE
stats-exporter: added stats-without-orphaned() and stats-with-legacy() options

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1089,6 +1089,8 @@ admin-guide-nav:
       url: /admin-guide/190_The_syslog-ng_manual_pages/009_syslog-ng_manual
     - title: "The syslog-ng.conf manual page"
       url: /admin-guide/190_The_syslog-ng_manual_pages/010_syslog-ng_conf
+    - title: "The persist-tool manual page"
+      url: /admin-guide/190_The_syslog-ng_manual_pages/011_persist-tool
   - title: "About us"
     url: /admin-guide/200_About/README
     subnav:

--- a/doc/_admin-guide/060_Sources/153_stats_exporter/000_stats_exporter_source_options.md
+++ b/doc/_admin-guide/060_Sources/153_stats_exporter/000_stats_exporter_source_options.md
@@ -24,7 +24,7 @@ These drivers have the following additional options:
 |Accepted values:| regular expression |
 |Default:        |  |
 
-*Description:* This option sets the query regex string which can be used to filter the output of a query type request.
+*Description:* This option sets the query regex string which can be used to filter the output of a `query` type request.
 
 ## stat-format()
 
@@ -36,6 +36,20 @@ These drivers have the following additional options:
 - `csv` – comma-separated values format
 - `kv` – key-value pairs, one per line
 - `prometheus` – Prometheus-compatible exposition format
+
+## stats-without-orphaned()
+
+|Accepted values:| yes \| no |
+|Default:        | no |
+
+*Description:* If this option is set to `yes`, the output of a `stats` type request will not include abandoned counters, similar to the `without-orphaned-metrics` option available in `syslog-ng-ctl`.
+
+## stats-with-legacy()
+
+|Accepted values:| yes \| no |
+|Default:        | no |
+
+*Description:* If this option is set to `yes`, the output of a `stats` type request — only when using the `prometheus` format — will not include legacy counters, similar to the `with-legacy-metrics` option available in `syslog-ng-ctl`.
 
 ## scrape-pattern()
 


### PR DESCRIPTION
Depends on https://github.com/syslog-ng/syslog-ng/pull/5424