### PR TITLE
Deprecated options snippet usage

### DIFF
--- a/_includes/doc/admin-guide/options/deprecated-options.md
+++ b/_includes/doc/admin-guide/options/deprecated-options.md
@@ -1,2 +1,2 @@
-**NOTE:** The deprecated `{{ include.old }}()` option is an alias for the `{{ include.new }}()` option, retained for compatibility with earlier {{ site.product.short_name }} versions, but it may be removed at any time without further notice!
+**NOTE:** The deprecated `{{ include.old }}` option is an alias for the `{{ include.new }}` option, retained for compatibility with earlier {{ site.product.short_name }} versions, but it may be removed at any time without further notice!
 {: .notice--info}

--- a/doc/_admin-guide/020_The_concepts_of_syslog-ng/010_Things_to_consider.md
+++ b/doc/_admin-guide/020_The_concepts_of_syslog-ng/010_Things_to_consider.md
@@ -21,9 +21,9 @@ There are two drivers you can use: the **network()** driver and the
 **syslog()** driver. The syslog() driver is for the syslog (RFC-5424)
 protocol and the network() driver is for the BSD (RFC-3164) protocol.
 
-The tcp() and udp() drivers are now deprecated, they are essentially
-equivalent with the network(transport(tcp)) and network(transport(udp))
-drivers.
+{% include doc/admin-guide/options/deprecated-options.md old='tcp()' new='network(transport(tcp))' %}
+
+{% include doc/admin-guide/options/deprecated-options.md old='udp()' new='network(transport(udp))' %}
 
 In addition to selecting the driver to use, both drivers allow you to
 use different transport-layer protocols: TCP and UDP, and optionally

--- a/doc/_admin-guide/070_Destinations/130_MongoDB/README.md
+++ b/doc/_admin-guide/070_Destinations/130_MongoDB/README.md
@@ -63,18 +63,4 @@ destination d_mongodb {
 };
 ```
 
-The following example shows the same setup using the deprecated
-libmongo-client syntax, and is equivalent with the previous example.
-
-```config
-destination d_mongodb {
-    mongodb(
-        servers("localhost:27017")
-        database("syslog")
-        collection("messages")
-        value-pairs(
-            scope("selected-macros" "nv-pairs" "sdata")
-        )
-    );
-};
-```
+{% include doc/admin-guide/options/deprecated-options.md old='libmongo client syntax' new='mongodb' %}

--- a/doc/_admin-guide/090_Global_options/000_Global_options.md
+++ b/doc/_admin-guide/090_Global_options/000_Global_options.md
@@ -276,12 +276,7 @@ Higher log-levels automatically include messages from lower log-levels:
 
 ## mark() (DEPRECATED)
 
-|  Accepted values:|   number|
-  |Default:|           1200|
-
-*Description:* The mark-freq() option is an alias for the deprecated
-mark() option. This is retained for compatibility with {{ site.product.short_name }} version
-1.6.x.
+{% include doc/admin-guide/options/deprecated-options.md old='mark()' new='mark-freq()' %}
 
 {% include doc/admin-guide/options/mark-freq.md %}
 
@@ -306,7 +301,7 @@ configured to do so.
 
 ## pass-unix-credentials() (DEPRECATED)
 
-The `pass-unix-credentials()` option has been deprecated in {{ site.product.short_name }} 3.35 and later versions. Use the `so-passcred()` option.
+{% include doc/admin-guide/options/deprecated-options.md old='pass-unix-credentials()' new='so-passcred()' %}
 
 {% include doc/admin-guide/options/perm.md %}
 
@@ -455,19 +450,19 @@ Possible values:
 
 ## stats-freq() (DEPRECATED)
 
-This is a deprecated legacy option. Use stats(freq()) instead.
+{% include doc/admin-guide/options/deprecated-options.md old='stats-freq()' new='stats(freq())' %}
 
 ## stats-level() (DEPRECATED)
 
-This is a deprecated legacy option. Use stats(level()) instead.
+{% include doc/admin-guide/options/deprecated-options.md old='stats-level()' new='stats(level())' %}
 
 ## stats-max-dynamics() (DEPRECATED)
 
-This is a deprecated legacy option. Use stats(max-dynamics()) instead.
+{% include doc/admin-guide/options/deprecated-options.md old='stats-max-dynamics()' new='stats(max-dynamics())' %}
 
 ## sync() or sync-freq() (DEPRECATED)
 
-Obsolete aliases for flush-lines().
+{% include doc/admin-guide/options/deprecated-options.md old='sync() and sync-freq()' new='flush-lines()' %}
 
 ## threaded()
 
@@ -482,14 +477,6 @@ Multithreading and scaling in {{ site.product.short_name }}.
 {% include doc/admin-guide/options/time-reap.md %}
 
 {% include doc/admin-guide/options/time-reopen.md %}
-
-## time-sleep() (DEPRECATED)
-
-|  Accepted values:|   number|
-  |Default:|           0|
-
-*Description:* The time to wait in milliseconds between each invocation
-of the poll() iteration.
 
 {% include doc/admin-guide/options/time-zone.md %}
 


### PR DESCRIPTION
Used referable deprecation snippet wherever it was appropriate to use.

Signed-off-by: Zsolt Gyulai (zgyulai) <zsolt.gyulai@quest.com>
