### PR TITLE
Fix typo @LNSTRING@ -> @NLSTRING@

### DIFF
--- a/doc/_admin-guide/120_Parser/006_db_parser/003_Creating_pattern_databases/001_Pattern_parsers.md
+++ b/doc/_admin-guide/120_Parser/006_db_parser/003_Creating_pattern_databases/001_Pattern_parsers.md
@@ -96,17 +96,17 @@ Windows security auditing logs.
 <pattern>Example-PC\Example: Security Microsoft Windows security auditing.: [Success Audit] A new process has been created.
 
     Subject:
-    Security ID: @LNSTRING:.winaudit.SubjectUserSid@
-    Account Name: @LNSTRING:.winaudit.SubjectUserName@
-    Account Domain: @LNSTRING:.winaudit.SubjectDomainName@
-    Logon ID: @LNSTRING:.winaudit.SubjectLogonId@
+    Security ID: @NLSTNING:.winaudit.SubjectUserSid@
+    Account Name: @NLSTNING:.winaudit.SubjectUserName@
+    Account Domain: @NLSTNING:.winaudit.SubjectDomainName@
+    Logon ID: @NLSTNING:.winaudit.SubjectLogonId@
 
     Process Information:
-    New Process ID: @LNSTRING:.winaudit.NewProcessId@
-    New Process Name: @LNSTRING:.winaudit.NewProcessName@
-    Token Elevation Type: @LNSTRING:.winaudit.TokenElevationType@
-    Creator Process ID: @LNSTRING:.winaudit.ProcessId@
-    Process Command Line: @LNSTRING:.winaudit.CommandLine@
+    New Process ID: @NLSTNING:.winaudit.NewProcessId@
+    New Process Name: @NLSTNING:.winaudit.NewProcessName@
+    Token Elevation Type: @NLSTNING:.winaudit.TokenElevationType@
+    Creator Process ID: @NLSTNING:.winaudit.ProcessId@
+    Process Command Line: @NLSTNING:.winaudit.CommandLine@
 
     Token Elevation Type indicates the type of token that was assigned to the new process in accordance with User Account Control policy.</pattern>
 ```


### PR DESCRIPTION
The patterndb pattern is N-L-STRING (New-Line-String), the two first letters have been mixed-up.  Probably copy/pasted from this comment on the GitHub PR that added support for this pattern:
https://github.com/syslog-ng/syslog-ng/pull/768#issuecomment-219739543

