### PR TITLE
Fix cross-browser search keyboard and focus issues

### DIFF
--- a/_js/custom/navigation.js
+++ b/_js/custom/navigation.js
@@ -227,8 +227,8 @@ $(function () {
 
       var updated = false;
       // Get the relative URL value and update the browser URL
-      // Use originalTarget or explicitTarget to get the correct one even for clicks from the tooltips
-      var anchorElement = event.originalTarget.closest('a');
+      // Use originalTarget (Firefox) or target (all other browsers) to get the clicked element
+      var anchorElement = (event.originalTarget || event.target).closest('a');
 
       if (anchorElement) {
         var url = new URL(anchorElement.href);

--- a/_js/custom/navigation.js
+++ b/_js/custom/navigation.js
@@ -794,7 +794,7 @@ $(function () {
       if ($(".initial-content").hasClass("is--hidden")) {
         // set focus on input
         setTimeout(function () {
-          var input = $(".search-content__form").find("input");
+          var input = $(".search-content__form").find("input[type='search']");
           input.trigger("focus");
           input.trigger("select");
         }, 100);

--- a/_js/custom/navigation.js
+++ b/_js/custom/navigation.js
@@ -767,21 +767,24 @@ $(function () {
   // -------------
 
   if (searchEnabled) {
-    // Close search screen with Esc key or toggle with predefined hotKey
-    $(document).on('keyup', function (event) {
-      // Define the desired hotkey (in this case, Ctrl + Shift + F)
-      var searchHotkey = { ctrlKey: true, shiftKey: true, key: 'F' };
-
+    // Close search panel with Esc key — capture phase so stopPropagation in inner
+    // elements cannot block it
+    document.addEventListener('keyup', function (event) {
       if (event.keyCode === 27) {
         if ($(".initial-content").hasClass("is--hidden"))
           toggleSearch(event);
       }
-      else if (event.ctrlKey === searchHotkey.ctrlKey &&
-        event.shiftKey === searchHotkey.shiftKey &&
-        event.key === searchHotkey.key) {
+    }, true);
+
+    // Toggle search panel with Ctrl+Shift+F — capture phase + preventDefault so the
+    // browser/OS cannot intercept the combination before the page handles it
+    document.addEventListener('keydown', function (event) {
+      if (event.ctrlKey && event.shiftKey &&
+          (event.key.toUpperCase() === 'F' || event.code === 'KeyF')) {
+        event.preventDefault();
         toggleSearch(event);
       }
-    });
+    }, true);
 
     function toggleSearch(event) {
       $(".search-content").toggleClass("is--visible");

--- a/_js/lunr/lunr-en.js
+++ b/_js/lunr/lunr-en.js
@@ -1154,7 +1154,7 @@ $(document).ready(function() {
       resultdiv.append(searchitem);
     }
   }
-  $('input#search').on('keyup', onKeyUp);
+  $('input#search').on('input', onKeyUp);
   
   // Function to update fuzzy checkbox state based on exact-only mode
   function updateFuzzyCheckboxState() {

--- a/_js/main.min.js
+++ b/_js/main.min.js
@@ -8584,7 +8584,7 @@ $(function() {
         if (!event.shiftKey && !event.ctrlKey && !event.altKey && !event.metaKey) {
             if (tooltipTarget) hideTooltip(true);
             var updated = false;
-            var anchorElement = event.originalTarget.closest("a");
+            var anchorElement = (event.originalTarget || event.target).closest("a");
             if (anchorElement) {
                 var url = new URL(anchorElement.href);
                 if (url.origin === window.location.origin && anchorElement.target !== "_blank" && sameCollection(url, window.location)) {
@@ -8910,25 +8910,24 @@ $(function() {
         stickySideBar();
     });
     if (searchEnabled) {
-        $(document).on("keyup", function(event) {
-            var searchHotkey = {
-                ctrlKey: true,
-                shiftKey: true,
-                key: "F"
-            };
+        document.addEventListener("keyup", function(event) {
             if (event.keyCode === 27) {
                 if ($(".initial-content").hasClass("is--hidden")) toggleSearch(event);
-            } else if (event.ctrlKey === searchHotkey.ctrlKey && event.shiftKey === searchHotkey.shiftKey && event.key === searchHotkey.key) {
+            }
+        }, true);
+        document.addEventListener("keydown", function(event) {
+            if (event.ctrlKey && event.shiftKey && (event.key.toUpperCase() === "F" || event.code === "KeyF")) {
+                event.preventDefault();
                 toggleSearch(event);
             }
-        });
+        }, true);
         function toggleSearch(event) {
             $(".search-content").toggleClass("is--visible");
             $(".search-content__form").toggleClass("is--visible");
             $(".initial-content").toggleClass("is--hidden");
             if ($(".initial-content").hasClass("is--hidden")) {
                 setTimeout(function() {
-                    var input = $(".search-content__form").find("input");
+                    var input = $(".search-content__form").find("input[type='search']");
                     input.trigger("focus");
                     input.trigger("select");
                 }, 100);


### PR DESCRIPTION
## Problem

The search functionality had several cross-browser compatibility issues:

- **Non-Firefox browsers** (Chrome, Opera, Safari): clicking navigation links threw a `TypeError` because `event.originalTarget` is Firefox-only
- **Opera**: the Ctrl+Shift+F hotkey never fired because jQuery's bubbling-phase `keydown` handlers are blocked by `stopPropagation` calls inside the page
- **All browsers**: the native clear button (×) on the search field did not trigger a search, because it fires `input` but not `keyup`
- **Non-Firefox browsers**: opening the search panel focused the fuzzy-match checkbox instead of the text input

## Changes

- `event.originalTarget || event.target` — falls back to standard `event.target` on non-Firefox browsers
- Switched keyboard handlers from jQuery `$(document).on()` (bubbling) to `document.addEventListener(..., true)` (capture phase); also moved the hotkey from `keyup` to `keydown` with `preventDefault()`
- Changed search input listener from `keyup` to `input` event
- Changed `find('input')` to `find("input[type='search']")` to target only the text input