### PR TITLE
Reword %f format option description

### DIFF
--- a/doc/_admin-guide/120_Parser/005_dates_parser/000_Date_parser_options.md
+++ b/doc/_admin-guide/120_Parser/005_dates_parser/000_Date_parser_options.md
@@ -38,7 +38,7 @@ date. You can use the following format elements:
 | %C | ctime format: Sat Nov 19 21:05:57 1994                         |
 | %d | numeric day of the month, with leading zeros (eg 01..31)       |
 | %e | like %d, but a leading zero is replaced by a space (eg 1..31)  |
-| %f | microseconds, leading 0's, extra digits are silently discarded |
+| %f | fractional second with a precision up-to the nanosecond (extra digits are silently discarded). Can start with a '.' |
 | %D | MM/DD/YY                                                       |
 | %G | GPS week number (weeks since January 6, 1980)                  |
 | %h | month, abbreviated                                             |


### PR DESCRIPTION
A `%f` will successfully parse "123" as 123000000ns and does not _need_ a nanosecond precision as the description implied.

Reword it to make this more straightforward.
While here add a note that the value can start with a '.' (allowing to have the same parser `%H:%M:%S%f` accepting both "01:02:03" and "01:02:03.040506").