### PR TITLE
Clarify set-facility() function details

### DIFF
--- a/doc/_admin-guide/110_Template_and_rewrite/001_Modifying_messages/003_Setting_facility.md
+++ b/doc/_admin-guide/110_Template_and_rewrite/001_Modifying_messages/003_Setting_facility.md
@@ -4,9 +4,9 @@ short_title: Setting facility
 id: adm-temp-facility
 description: >-
   It is possible to set the facility field with the set-facility() rewrite
-  function. When set, the set-facility() rewrite function will only
-  rewrite the `PRIORITY` field in the message to the first parameter value
-  specified in the function.
+  function. The set-facility() rewrite function rewrites only the facility
+  part of the `PRIORITY` value in the message, while preserving the
+  severity part.
 ---
 
 {% include doc/admin-guide/notes/not-valid-param.md %}
@@ -37,10 +37,12 @@ set-facility( "parameter1" );
 
 The set-facility() rewrite function accepts the following values:
 
-- numeric strings: \[0-7\]
+- numeric strings: \[0-127\]
 
-- named values: emerg, emergency, panic, alert, crit, critical, err,
-    error, warning, warn, notice, info, informational, debug
+- named values: kern, user, mail, daemon, auth, syslog, lpr, news,
+  uucp, cron, authpriv, megasafe, ftp, ntp, security, console,
+  solaris-cron, local0, local1, local2, local3, local4, local5,
+  local6, local7
 
 ### Example usage for the set-facility() rewrite function
 
@@ -49,7 +51,8 @@ rewrite function.
 
 ```config
 rewrite {
-set-facility("info");
+set-facility("mail");
 set-facility("6");
-set-facility("${.json.severity}");};
+set-facility("${.json.facility}");
+};
 ```


### PR DESCRIPTION
Updated the description and accepted values for the set-facility() rewrite function, clarifying its behavior and expanding the list of named values.

Fixes: https://github.com/syslog-ng/syslog-ng.github.io/issues/177