### PR TITLE
Replace `regexp` => `prefix-garbage` for `multi-line-mode()`

### DIFF
--- a/_includes/doc/admin-guide/options/multi-line-mode-header.md
+++ b/_includes/doc/admin-guide/options/multi-line-mode-header.md
@@ -1,7 +1,7 @@
 ## multi-line-mode()
 
-| Accepted values: | `indented`, `regexp`, `empty-line-separated` |
-| Default:         | empty string                                 |
+| Accepted values: | `indented`, `prefix-garbage`, `prefix-suffix`, `empty-line-separated` |
+| Default:         | empty string                                                          |
 
 *Description:* Use the multi-line-mode() option when processing
 multi-line messages. The {{ site.product.short_name }} application provides the

--- a/_includes/doc/admin-guide/options/multi-line-prefix.md
+++ b/_includes/doc/admin-guide/options/multi-line-prefix.md
@@ -54,7 +54,7 @@ expression is the following:
 source s_file{
     file("/var/log/tomcat6/catalina.2010-06-09.log"
     follow-freq(0) 
-    multi-line-mode(regexp) 
+    multi-line-mode(prefix-garbage)
     multi-line-prefix("[0-9]{4}\.[0-9]{2}\.[0-9]{2}\.") 
     flags(no-parse));
 };


### PR DESCRIPTION
https://github.com/syslog-ng/syslog-ng/pull/125 introduced `prefix-garbage` to replace `regexp`.  The documentation correctly describe the `indented`, `prefix-garbage`, `prefix-suffix` and `empty-line-separated` modes, but the header only list the legacy `regexp` value, and an example still use this value.

Update the documentation to consistently use the new wording.
